### PR TITLE
[Feature] Add devcontainer support w/Python,pipx,fabric installed

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "python:3.12",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "apt-get update && apt-get install -y pipx apt-utils ffmpeg && pipx install . && rm -rf /var/lib/apt/lists/* && apt-get clean && pipx ensurepath"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "apt-get update && apt-get install -y pipx apt-utils ffmpeg && pipx install . && rm -rf /var/lib/apt/lists/* && apt-get clean && pipx ensurepath"
+	"postCreateCommand": "apt-get update && apt-get install -y pipx apt-utils ffmpeg && pipx install . && rm -rf /var/lib/apt/lists/* && apt-get clean && echo \"export PATH=\\\"\\$PATH:/~/.local/bin\\\"\" >> ~/.bashrc"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "apt-get update && apt-get install -y pipx apt-utils ffmpeg && pipx install . && rm -rf /var/lib/apt/lists/* && apt-get clean && echo \"export PATH=\\\"\\$PATH:/~/.local/bin\\\"\" >> ~/.bashrc"
+	"postCreateCommand": "apt-get update && apt-get install -y pipx apt-utils ffmpeg && pipx install . && rm -rf /var/lib/apt/lists/* && apt-get clean && echo \"export PATH=\\\"\\$PATH:~/.local/bin\\\"\" >> ~/.bashrc"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
## What this Pull Request (PR) does
Allow CodeSpaces and VSCode or other tools that use devcontainers to open project easily and just configure their API keys. 

CodeSpaces can just be opened from the Code dropbox when browsing the repo and clicking CodeSpaces instead of local easily.

Note:
This devcontainer is not hardened for security purposes and runs as root to keep customization simple.A future merge of Dockerfile should improve the security and be utilized after it's merged. 

Feedback and suggestions for improvements and hardening are welcome! 🐱

## Related issues
PR [#327](https://github.com/danielmiessler/fabric/pull/327) - Proposed Dockerfile which could be used after merging that PR. Once that's merged I can update this PR however as committed it stands on it's own as a PR.  
[#25](https://github.com/danielmiessler/fabric/issues/25)  
[#275](https://github.com/danielmiessler/fabric/issues/275)  
